### PR TITLE
Stella: Skip opening Stealth dialogue when spawning at checkpoint

### DIFF
--- a/scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth_components/stella_stealth.dialogue
+++ b/scenes/quests/story_quests/stella/1_stella_stealth/stella_stealth_components/stella_stealth.dialogue
@@ -1,5 +1,7 @@
 # SPDX-FileCopyrightText: The Threadbare Authors
 # SPDX-License-Identifier: MPL-2.0
 ~ start
+if str(GameState.current_spawn_point) != ""
+	=> END
 Stella’s journey takes her deep into the heart of Guatemala, where she finds a Mayan firekeeper tending an unlit hearth in a village. 
 => END


### PR DESCRIPTION
This scene uses a Cinematic to play an opening narration. Cinematic plays its dialogue unconditionally. But it is weird to have the narration be replayed after you are caught and respawn.

We can't always distinguish between starting the level for the first time and reloading it, but if the player has reached a spawn point we can detect that from the dialogue since the GameState global is accessible there. Skip the narration in that case.